### PR TITLE
Replace color to weak color which has same lightness as the original color

### DIFF
--- a/backend/data/sampleHTML
+++ b/backend/data/sampleHTML
@@ -33,7 +33,7 @@
 </head>
 
 <body>
-<div style="background-color:#004857">
+<div style="background-color:#123456">
     <h1 style="color:#005caf;">Custom Example Domain</h1>
     <p>This domain is for use in illustrative examples in documents. You may use this
     domain in literature without prior coordination or asking for permission.</p>

--- a/backend/data/sampleHTML
+++ b/backend/data/sampleHTML
@@ -32,19 +32,20 @@
     </style>    
 </head>
 
-<body>
-<div style="background-color:#123456">
-    <h1 style="color:#005caf;">Custom Example Domain</h1>
-    <p>This domain is for use in illustrative examples in documents. You may use this
-    domain in literature without prior coordination or asking for permission.</p>
-    <p><a href="https://www.iana.org/domains/example">More information...</a></p>
-</div>
-<div style="background-color:#247833;">
-    <h1 style="color:#5caf00;">Custom Example Domain</h1>
-    <p>This domain is for use in illustrative examples in documents. You may use this
-    domain in literature without prior coordination or asking for permission.</p>
-    <p><a href="https://www.iana.org/domains/example">More information...</a></p>
-</div>
+<body id="body">
+
+    <div style="background-color:#123456">
+        <h1 style="color:#005caf;">Custom Example Domain</h1>
+        <p>This domain is for use in illustrative examples in documents. You may use this
+        domain in literature without prior coordination or asking for permission.</p>
+        <p><a href="https://www.iana.org/domains/example">More information...</a></p>
+    </div>
+    <div style="background-color:#247833;">
+        <h1 style="color:#5caf00;">Custom Example Domain</h1>
+        <p>This domain is for use in illustrative examples in documents. You may use this
+        domain in literature without prior coordination or asking for permission.</p>
+        <p><a href="https://www.iana.org/domains/example">More information...</a></p>
+    </div>
 
 <p><input type="text" placeholder="사용 불가 텍스트"></p>
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "axios": "^0.27.2",
+    "color-convert": "^2.0.1",
     "cookie-parser": "~1.4.4",
     "cors": "^2.8.5",
     "debug": "~2.6.9",

--- a/backend/services/colorWeakness.js
+++ b/backend/services/colorWeakness.js
@@ -1,4 +1,4 @@
-const color_converter = require('./getColor');
+const weak_color = require('./getColor');
 
 const getStyle = () => {
     const style = [];
@@ -20,7 +20,7 @@ const getRenderedHtml = (html_data) => {
     if(pattern.test(html_data)) {
         const target_list = [...new Set(html_data.match(pattern))];
         for(const target of target_list) {
-            html_data = html_data.replace(new RegExp(target, 'gi'), color_converter.getColor(target));
+            html_data = html_data.replace(new RegExp(target, 'gi'), weak_color.getColor(target));
         }
     }
     return html_data;

--- a/backend/services/getColor.js
+++ b/backend/services/getColor.js
@@ -1,3 +1,5 @@
+var convert = require('color-convert');
+
 const ColorTable = {
     BLACK: "#000000",
     GRAY: "#999999",
@@ -13,6 +15,7 @@ const ColorTable = {
 
 const getColor = (targetColor) => {
     const target_color_vector = colorToVector(targetColor);
+    const target_lightness = convert.hex.hsl(targetColor.substr(1))[2];
     let color = null;
     let min_distance = getDistanceOfVector([0, 0, 0], [255, 255, 255]);
     Object.keys(ColorTable).forEach(key => {
@@ -22,6 +25,9 @@ const getColor = (targetColor) => {
             color = ColorTable[key];
         }
     });
+    const hsl = convert.hex.hsl(color.substr(1));
+    hsl[2] = target_lightness;
+    color = '#'+convert.hsl.hex(hsl);
     return color;
 };
 


### PR DESCRIPTION
- data/SampleHTML
    - #3 테스트 및 해결을 위한 색상 변경
    - 프론트와 동일한 환경 조성을 위해 body id 추가
- services/colorWeakness.js
    - 새로운 color-convert api로 인한 헷갈림 방지를 위해 getColor의 모듈명 수정 : color_converter -> weak_color
- services/getColor.js
    - 원본 색상의 명도 추출
    - 원본 색상에 매칭되는 색약 색상 선택
    - 색약 색상의 명도를 원본 색상의 명도와 동일하게 변경 후 반환