### PR TITLE
Exception handling, Refactoring, Fix korean recognition error

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -28,17 +28,14 @@ app.use('/', indexRouter);
 app.use('/style', styleRouter);
 
 // catch 404 and forward to error handler
-app.use((req, res, next) => {
+app.use((_, __, next) => {
     next(createError(404));
 });
 
 // error handler
 app.use((err, req, res, next) => {
-    // set locals, only providing error in development
-    res.locals.message = err.message;
-    res.locals.error = req.app.get('env') === 'development' ? err : {};
-
-     // render the error page
+    // render the error page
+    console.error(err.stack);
     res.status(err.status || 500);
     res.end(err.message);
 });

--- a/backend/app.js
+++ b/backend/app.js
@@ -1,17 +1,16 @@
-const createError = require('http-errors');
-const express = require('express');
+const createHttpError = require('http-errors');
 const path = require('path');
 const cookieParser = require('cookie-parser');
-
 const logger = require('morgan');
 const cors = require('cors');
+
+const express = require('express');
+const app = express();
 
 const indexRouter = require('./routes/index');
 const styleRouter = require('./routes/style');
 
 const PORT = 4000;
-
-const app = express();
 
 // view engine setup
 app.set('views', path.join(__dirname, 'views'));
@@ -29,7 +28,7 @@ app.use('/style', styleRouter);
 
 // catch 404 and forward to error handler
 app.use((_, __, next) => {
-    next(createError(404));
+    next(createHttpError(404));
 });
 
 // error handler

--- a/backend/package.json
+++ b/backend/package.json
@@ -17,6 +17,7 @@
     "morgan": "~1.9.1",
     "pug": "2.0.0-beta11",
     "request": "^2.88.2",
+    "urlencode": "^1.1.0",
     "xmlhttprequest": "^1.8.0"
   },
   "devDependencies": {

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -22,8 +22,9 @@ router.get('/', async (req, res, next) => {
     });
     const html = result.data;
     if (!html) return res.status(404).send('HTML을 받아오지 못했습니다.');
+
     const modified_html = modifyLink(url, html);
-    res.send(modified_html);
+    return res.send(modified_html);
 });
 
 module.exports = router;

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -1,4 +1,5 @@
 const axios = require('axios');
+var urlencode = require('urlencode'); 
 const express = require('express');
 const isUrl = require('../services/isUrl');
 const router = express.Router();
@@ -6,7 +7,7 @@ const router = express.Router();
 const modifyLink = require('../services/modifyLink');
 
 router.get('/', async (req, res, next) => {
-    const url = req.query.url;
+    const url = urlencode.decode(req.query.url);
     if (!url) return res.status(400).end('URL을 파라미터에 포함해야 합니다.');
     if (!isUrl(url)) return res.status(400).end('잘못된 형식의 URL입니다.');
 

--- a/backend/routes/style.js
+++ b/backend/routes/style.js
@@ -15,7 +15,7 @@ const internal_selector = '#body';
 router.get('/color-test', (req, res) => {
     res.writeHead('200', { 'Content-Type': 'text/html; charset=utf8' });
     req.app.render('color-test', function (err, html) {
-        res.end(html);
+        return res.send(html);
     });
 });
 
@@ -37,7 +37,7 @@ router.post('/color', (req, res) => {
     style = css_manager.makeStyle(internal_selector, color_mode.setting, color_mode.strict_mode)
     const result = css_manager.addStyle(html_data, style, style_category+' '+style_name);
     res.writeHead('200', { 'Content-Type': 'text/html; charset=utf8' });
-    res.end(result);
+    return res.send(result);
 });
 
 // 글자크기 API
@@ -49,7 +49,7 @@ router.post('/text', (req, res) => {
     const style = `${internal_selector} { font-size: ${parseInt(text_size)}% !important; }`;
     const result = css_manager.addStyle(html_data, style, style_category+' '+style_name);
     res.writeHead('200', { 'Content-Type': 'text/html; charset=utf8' });
-    res.end(result);
+    return res.send(result);
 });
 
 module.exports = router;

--- a/backend/routes/style.js
+++ b/backend/routes/style.js
@@ -9,7 +9,7 @@ const example_html_data = fs.readFileSync('data/sampleHTML', 'utf8');
 const no_url_html_data = fs.readFileSync('data/noUrlHTML', 'utf-8');
 const internal_selector = '#body';
 
-// TODO: 색상 변경 모드 API
+// 색상 변경 모드 API
 
 // 테스트용 페이지
 router.get('/color-test', (req, res) => {
@@ -40,7 +40,7 @@ router.post('/color', (req, res) => {
     res.end(result);
 });
 
-// TODO: 글자크기 API
+// 글자크기 API
 router.post('/text', (req, res) => {
     const style_category = 'text';
     const style_name = req.body.style_change;

--- a/backend/services/isUrl.js
+++ b/backend/services/isUrl.js
@@ -1,0 +1,6 @@
+const isUrl = (url) => {
+    const url_regex = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)/gi;
+    return url_regex.test(url);
+}
+
+module.exports = isUrl;

--- a/backend/services/modifyLink.js
+++ b/backend/services/modifyLink.js
@@ -16,14 +16,9 @@ const modifyLink = (url, html) => {
 // input parameter: https://example.com/abc/def
 // return: https://example.com
 const getContextPath = (url) => {
-    let match = url.match(/https:\/\/[^\/]*/);
+    let match = url.match(/https?:\/\/[^\/]*/);
     if (match)
         return match[0];
-    
-    match = url.match(/http:\/\/[^\/]*/);
-    if (match)
-        return match[0];
-    
     return null;
 }
 


### PR DESCRIPTION
### PR 요약
- 서버의 컨트롤러 단에 예외 처리 로직 추가
  - 일단 급한 (URL 처리하는) 인덱스 라우터에만 추가. 추후 리팩토링하면서 이외의 라우터에도 추가할 것
- 리팩토링
  - 응답 형식 일관적으로 수정, 불필요한 주석 내용 수정 등
- 한글이 포함된 URL 인식 오류 문제 해결
  - 로직 실행 전 URL 디코딩 과정을 거침

---

### 주의할 점
1. 응답 형식의 경우 express에서 제공하는 end()를 사용하고 있었는데, end()는 주로 결과로 돌려줄 데이터가 없는 경우에 사용한다고 합니다. 이러한 경우(문자열을 돌려주어야 하는 경우) send()를 사용하는 것이 옳다고 하여 일관적으로 변경하였습니다.
2. 응답의 return문은 빠져야 되는 게 맞으나 비동기 오류 문제로 일시적으로 전부 명시적 반환 처리하였습니다. (근데 진짜 왜지 👀)